### PR TITLE
Properly dispose

### DIFF
--- a/src/EmbeddedMail/EmbeddedMail.csproj
+++ b/src/EmbeddedMail/EmbeddedMail.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EmbeddedMail</RootNamespace>
     <AssemblyName>EmbeddedMail</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/EmbeddedMail/ISmtpSession.cs
+++ b/src/EmbeddedMail/ISmtpSession.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Mail;
+using System.Text;
 using EmbeddedMail.Handlers;
 
 namespace EmbeddedMail
@@ -36,9 +37,31 @@ namespace EmbeddedMail
         {
             if (!_socket.Connected) return;
 
-            _reader = new StreamReader(_socket.Stream);
-            _writer = new StreamWriter(_socket.Stream) { AutoFlush = true };
+            _reader = new StreamReader(
+              stream: _socket.Stream,
+              // the next three values are the defaults when calling the overload that just takes a Stream
+              encoding: Encoding.UTF8,
+              detectEncodingFromByteOrderMarks: true,
+              bufferSize: 1024,
+              // the prevoius three values are the defaults when calling the overload that just takes a Stream
+              leaveOpen: true // don't dispose objects given to you
+            );
             
+            Encoding GetDefaultStreamWriterEncoding() {
+              using (var writer = new StreamWriter(Stream.Null)) {
+                return writer.Encoding;
+              }
+            }
+            
+            _writer = new StreamWriter(
+              stream: _socket.Stream,
+              // the next two values are the defaults when calling the overload that just takes a Stream
+              encoding: GetDefaultStreamWriterEncoding(),
+              bufferSize: 1024,
+              // the previous two values are the defaults when calling the overload that just takes a Stream
+              leaveOpen: true // don't dispose objects given to you
+            ) { AutoFlush = true, NewLine = "\r\n" };
+
             _writer.WriteLine("220 localhost Server Ready");
             var isMessageBody = false;
             while(_socket.Connected)


### PR DESCRIPTION
Fixes #4 

In order to dispose objects in the reverse order in which they were created and continue to use `StreamReader` and `StreamWriter`, I increased the target .Net Framework from 4.0 to 4.5 (because the needed constructor overloads for `StreamReader` and `StreamWriter` were added in 4.5).