### PR TITLE
only send 421 command when aborting the session

### DIFF
--- a/src/EmbeddedMail/EmbeddedSmtpServer.cs
+++ b/src/EmbeddedMail/EmbeddedSmtpServer.cs
@@ -115,7 +115,12 @@ namespace EmbeddedMail
             {
                 OnMessage = (msg) => _messages.Add(msg)
             };
-            session.Start();
+            
+            try {
+                session.Start();
+            } catch (Exception) {
+                session.WriteResponse("421 localhost error occured");
+            }
 
             _sessions.Add(session);
         }

--- a/src/EmbeddedMail/ISmtpSession.cs
+++ b/src/EmbeddedMail/ISmtpSession.cs
@@ -72,7 +72,8 @@ namespace EmbeddedMail
                      * ReadLine returns `null` if the end of the input stream is reached
                      * https://docs.microsoft.com/en-us/dotnet/api/system.io.streamreader.readline
                      */
-                    break;
+                    WriteResponse("421 localhost reached end of input stream while attempting to receive the next line from the client");
+                    return;
                 }
                 var token = SmtpToken.FromLine(line, isMessageBody);
                 
@@ -81,17 +82,17 @@ namespace EmbeddedMail
                 var handler = ProtocolHandlers.HandlerFor(token);
                 if(handler.Handle(token, this) == ContinueProcessing.Stop)
                 {
-                    break;
+                    return;
                 }
 
                 isMessageBody = token.IsData && token.IsMessageBody;
             }
+
+            SmtpLog.Warn("The socket closed unexpectedly");
         }
 
         public void Dispose()
         {
-            WriteResponse("421 localhost Closing transmission channel");
-
             _writer.Close();
             _reader.Close();
         }


### PR DESCRIPTION
The existing code always sends a 421 abort command at the end of the session ([during disposal](https://github.com/jmarnold/EmbeddedMail/blob/master/src/EmbeddedMail/ISmtpSession.cs#L93)).

This PR modifies that behavior to only send a 421 when some kind of exceptional behavior has occurred.  The text included with the 421 command is also tailored to the various cases that motivate the sending of the 421 command.